### PR TITLE
fix(merge): merge cmd bug

### DIFF
--- a/handlers/merge.go
+++ b/handlers/merge.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ldez/go-git-cmd-wrapper/v2/checkout"
 	"github.com/ldez/go-git-cmd-wrapper/v2/clone"
 	"github.com/ldez/go-git-cmd-wrapper/v2/config"
+	"github.com/ldez/go-git-cmd-wrapper/v2/fetch"
 	"github.com/ldez/go-git-cmd-wrapper/v2/git"
 	"github.com/ldez/go-git-cmd-wrapper/v2/global"
 	"github.com/ldez/go-git-cmd-wrapper/v2/merge"
@@ -66,9 +67,9 @@ func MergeMaster(username, password, repoUrl, branchName, master string) error {
 		return fmt.Errorf("git config error: %w, output: %s", err, output)
 	}
 
-	if output, err := git.Checkout(workingDir, checkout.Branch(master)); err != nil {
-		logger.Debug("git checkout error", "branch", master, "output", output)
-		return fmt.Errorf("git checkout error: %w, output: %s", err, output)
+	if output, err := git.Fetch(workingDir, fetch.All); err != nil {
+		logger.Debug("git fetch error", "branch", branchName, "output", output)
+		return fmt.Errorf("git fetch error: %w, output: %s", err, output)
 	}
 
 	if output, err := git.Checkout(workingDir, checkout.Branch(branchName)); err != nil {
@@ -76,9 +77,10 @@ func MergeMaster(username, password, repoUrl, branchName, master string) error {
 		return fmt.Errorf("git checkout error: %w, output: %s", err, output)
 	}
 
-	if output, err := git.Merge(workingDir, merge.Commits(master), merge.M(fmt.Sprintf("✨ merged %s", master))); err != nil {
+	remoteTargetBranch := fmt.Sprintf("%s/%s", defaultRemote, master)
+	if output, err := git.Merge(workingDir, merge.Commits(remoteTargetBranch), merge.M(fmt.Sprintf("✨ merged %s", master))); err != nil {
 		logger.Debug("git merge error", "output", output)
-		if output, err := git.Merge(workingDir, merge.NoFf, merge.Commits(master), merge.M(fmt.Sprintf("✨ merged %s", master))); err != nil {
+		if output, err := git.Merge(workingDir, merge.NoFf, merge.Commits(remoteTargetBranch), merge.M(fmt.Sprintf("✨ merged %s", master))); err != nil {
 			logger.Debug("git merge --no-ff error", "output", output)
 
 			mergeError := &MergeError{


### PR DESCRIPTION
# Fix Bug: Merge fails when merging from dev to master

## Error Logs

```
2025/12/10 07:09:58 DEBUG getCmd action=""
2025/12/10 07:09:58 DEBUG getCmd note=!merge
2025/12/10 07:09:58 DEBUG handler event=!merge
2025/12/10 07:09:58 INFO request method=POST uri=/mergebot/webhook/gitlab/ status=201 remote_ip=10.92.160.73 latency=231.135µs
2025/12/10 07:09:58 DEBUG variable not found varName=MERGE_BOT_SECRET projectId=891
2025/12/10 07:09:59 DEBUG git merge error output="merge: master - not something we can merge\n\nDid you mean this?\n\torigin/master\n"
2025/12/10 07:09:59 DEBUG git merge --no-ff error output="merge: master - not something we can merge\n\nDid you mean this?\n\torigin/master\n"
2025/12/10 07:09:59 ERROR handlerFunc returns err provider=gitlab event=!merge err="command.Merge returns err: git merge --no-ff error: exit status 1, output: merge: master - not something we can merge\n\nDid you mean this?\n\torigin/master\n"
```

## Reproduction Steps

- Target branch is `master`, but repository's default branch is not `master` (e.g., `main` or `dev`)
- Execute `!merge` command

## Root Cause

When default branch is not `master`, after `git clone` there's no local `master` branch, only `origin/master` remote reference. The original code uses `master` directly for merge, causing failure.

