### PR TITLE
fix: make ReviewRoulette return result data along with error

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -108,17 +108,14 @@ func ReviewRouletteCmd(command *handlers.Request, args string) error {
 	result, err := command.ReviewRoulette(num)
 	if err != nil {
 		if errors.Is(err, handlers.ReviewersAssignedError) {
-			if err := command.LeaveComment("🎲 Merge Request has assigned reviewers already"); err != nil {
-				return err
-			}
+			return command.LeaveComment("🎲 Merge Request has assigned reviewers already")
 		}
+
 		return fmt.Errorf("command.ReviewRoulette returns err: %w", err)
 	}
 
 	if len(result.Winners) == 0 {
-		if err := command.LeaveComment("🎲 No available players"); err != nil {
-			return err
-		}
+		return command.LeaveComment("🎲 No available players")
 	}
 
 	if err := command.LeaveComment(result.String()); err != nil {

--- a/commands.go
+++ b/commands.go
@@ -135,6 +135,10 @@ func NewMREvent(command *handlers.Request, args string) error {
 	}
 
 	if err := command.AutoAssignReviewers(); err != nil {
+		if errors.Is(err, handlers.ReviewersAssignedError) {
+			return nil
+		}
+
 		return fmt.Errorf("command.AssignReviewers returns err: %w", err)
 	}
 

--- a/commands.go
+++ b/commands.go
@@ -105,8 +105,28 @@ func ReviewRouletteCmd(command *handlers.Request, args string) error {
 		}
 	}
 
-	if err := command.ReviewRoulette(num); err != nil {
+	result, err := command.ReviewRoulette(num)
+	if err != nil {
+		if errors.Is(err, handlers.ReviewersAssignedError) {
+			if err := command.LeaveComment("🎲 Merge Request has assigned reviewers already"); err != nil {
+				return err
+			}
+		}
 		return fmt.Errorf("command.ReviewRoulette returns err: %w", err)
+	}
+
+	if len(result.Winners) == 0 {
+		if err := command.LeaveComment("🎲 No available players"); err != nil {
+			return err
+		}
+	}
+
+	if err := command.LeaveComment(result.String()); err != nil {
+		return err
+	}
+
+	if err := command.AssignReviewers(result.Winners); err != nil {
+		return err
 	}
 
 	return nil
@@ -117,7 +137,7 @@ func NewMREvent(command *handlers.Request, args string) error {
 		return fmt.Errorf("command.Greetings returns err: %w", err)
 	}
 
-	if err := command.AssignReviewers(); err != nil {
+	if err := command.AutoAssignReviewers(); err != nil {
 		return fmt.Errorf("command.AssignReviewers returns err: %w", err)
 	}
 

--- a/handlers/provider.go
+++ b/handlers/provider.go
@@ -13,12 +13,13 @@ var (
 	providers   = map[string]func() RequestProvider{}
 	providersMu sync.RWMutex
 
-	StatusError         = &Error{"Is it opened?"}
-	ValidError          = &Error{"Your request can't be merged, because either it has conflicts or state is not opened"}
-	RepoSizeError       = &Error{"Repository size is greater than allowed size"}
-	NotFoundError       = &Error{"Resource is not found"}
-	DiscussionError     = &Error{"Could not find resolvable discussion for merge request"}
-	CommitNotFoundError = &Error{"Commit was not found"}
+	StatusError            = &Error{"Is it opened?"}
+	ValidError             = &Error{"Your request can't be merged, because either it has conflicts or state is not opened"}
+	RepoSizeError          = &Error{"Repository size is greater than allowed size"}
+	NotFoundError          = &Error{"Resource is not found"}
+	DiscussionError        = &Error{"Could not find resolvable discussion for merge request"}
+	CommitNotFoundError    = &Error{"Commit was not found"}
+	ReviewersAssignedError = &Error{"MR has reviewers"}
 )
 
 type Error struct {

--- a/handlers/provider.go
+++ b/handlers/provider.go
@@ -1,8 +1,13 @@
 package handlers
 
 import (
+	"fmt"
 	"iter"
+	"slices"
+	"strings"
 	"sync"
+
+	"github.com/dustin/go-humanize/english"
 )
 
 const (
@@ -51,6 +56,81 @@ type MrInfo struct {
 	Description     string
 	ConfigContent   string
 	IsValid         bool
+}
+
+type Candidate struct {
+	Username    string
+	Count       int
+	StatusEmoji string
+	Status      string
+	Timezone    string
+	IsCodeOwner bool
+}
+
+func (c Candidate) IsAvailable() bool {
+	status := strings.ToLower(c.Status)
+
+	for _, s := range vacationStatuses {
+		if strings.Contains(status, s) {
+			return false
+		}
+	}
+
+	return !slices.Contains(emojiStatuses, c.StatusEmoji)
+}
+
+func (c Candidate) IsBot() bool {
+	for _, s := range botNicks {
+		if strings.Contains(strings.ToLower(c.Username), s) {
+			return true
+		}
+	}
+	return false
+}
+
+type RouletteResult struct {
+	TotalPlayers       int
+	UnavailablePlayers int
+	Winners            []string
+}
+
+func (r RouletteResult) String() string {
+	const rules string = `
+<details>
+<summary>
+Roulette rules:
+</summary>
+<pre>
+- Fetched all MR authors for last 3 months
+- Filtered only users with contributors permissions
+- Excluded:
+  - usernames from .mrbot.yaml config
+  - inactive users and bots
+  - users with emoji status: 🏖️, 🔴, ⛔, 🌴
+  - users with status: ooo, vacation, travel and parental leave
+- CODEOWNERS have higher priority
+</pre>
+</details>
+`
+
+	formatUsernames := make([]string, 0, len(r.Winners))
+	for _, u := range r.Winners {
+		formatUsernames = append(formatUsernames, "@"+u)
+	}
+
+	unavailableMessage := ""
+	if r.UnavailablePlayers > 0 {
+		players := english.Plural(r.UnavailablePlayers, "player", "")
+		unavailableMessage = fmt.Sprintf(", %s - unavailable", players)
+	}
+
+	return fmt.Sprintf(
+		"🎲 **Review Roulette** — %d contributors in the pool%s\n\n 🧠 Reviewers selected: %s\n\n %s",
+		r.TotalPlayers,
+		unavailableMessage,
+		strings.Join(formatUsernames, ","),
+		rules,
+	)
 }
 
 type Branches interface {

--- a/handlers/provider.go
+++ b/handlers/provider.go
@@ -128,7 +128,7 @@ Roulette rules:
 		"🎲 **Review Roulette** — %d contributors in the pool%s\n\n 🧠 Reviewers selected: %s\n\n %s",
 		r.TotalPlayers,
 		unavailableMessage,
-		strings.Join(formatUsernames, ","),
+		strings.Join(formatUsernames, ", "),
 		rules,
 	)
 }

--- a/handlers/request.go
+++ b/handlers/request.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/dustin/go-humanize/english"
 	"github.com/gasoid/merge-bot/v3/cache"
 	"github.com/gasoid/merge-bot/v3/logger"
 	"github.com/gasoid/merge-bot/v3/metrics"
@@ -281,81 +280,6 @@ func (r Request) ValidateSecret(secret string) bool {
 
 func (r Request) AwardEmoji(noteID int64, emoji string) error {
 	return r.provider.AwardEmoji(r.info.ProjectID, r.info.ID, noteID, emoji)
-}
-
-type Candidate struct {
-	Username    string
-	Count       int
-	StatusEmoji string
-	Status      string
-	Timezone    string
-	IsCodeOwner bool
-}
-
-func (c Candidate) IsAvailable() bool {
-	status := strings.ToLower(c.Status)
-
-	for _, s := range vacationStatuses {
-		if strings.Contains(status, s) {
-			return false
-		}
-	}
-
-	return !slices.Contains(emojiStatuses, c.StatusEmoji)
-}
-
-func (c Candidate) IsBot() bool {
-	for _, s := range botNicks {
-		if strings.Contains(strings.ToLower(c.Username), s) {
-			return true
-		}
-	}
-	return false
-}
-
-type RouletteResult struct {
-	TotalPlayers       int
-	UnavailablePlayers int
-	Winners            []string
-}
-
-func (r RouletteResult) String() string {
-	const rules string = `
-<details>
-<summary>
-Roulette rules:
-</summary>
-<pre>
-- Fetched all MR authors for last 3 months
-- Filtered only users with contributors permissions
-- Excluded:
-  - usernames from .mrbot.yaml config
-  - inactive users and bots
-  - users with emoji status: 🏖️, 🔴, ⛔, 🌴
-  - users with status: ooo, vacation, travel and parental leave
-- CODEOWNERS have higher priority
-</pre>
-</details>
-`
-
-	formatUsernames := make([]string, 0, len(r.Winners))
-	for _, u := range r.Winners {
-		formatUsernames = append(formatUsernames, "@"+u)
-	}
-
-	unavailableMessage := ""
-	if r.UnavailablePlayers > 0 {
-		players := english.Plural(r.UnavailablePlayers, "player", "")
-		unavailableMessage = fmt.Sprintf(", %s - unavailable", players)
-	}
-
-	return fmt.Sprintf(
-		"🎲 **Review Roulette** — %d contributors in the pool%s\n\n 🧠 Reviewers selected: %s\n\n %s",
-		r.TotalPlayers,
-		unavailableMessage,
-		strings.Join(formatUsernames, ","),
-		rules,
-	)
 }
 
 func (r Request) spinRoulette(num int) (*RouletteResult, error) {

--- a/handlers/request.go
+++ b/handlers/request.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"html/template"
 	"math/rand"
@@ -396,10 +395,6 @@ func (r Request) AutoAssignReviewers() error {
 	if ok {
 		result, err := r.reviewRoulette(r.config.AssignReviewers.ReviewerNumber)
 		if err != nil {
-			if errors.Is(err, ReviewersAssignedError) {
-				return nil
-			}
-
 			return err
 		}
 

--- a/handlers/request.go
+++ b/handlers/request.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"html/template"
 	"math/rand"
@@ -312,13 +313,13 @@ func (c Candidate) IsBot() bool {
 	return false
 }
 
-type rouletteResult struct {
-	totalPlayers       int
-	unavailablePlayers int
-	usernames          []string
+type RouletteResult struct {
+	TotalPlayers       int
+	UnavailablePlayers int
+	Winners            []string
 }
 
-func (r rouletteResult) String() string {
+func (r RouletteResult) String() string {
 	const rules string = `
 <details>
 <summary>
@@ -337,34 +338,34 @@ Roulette rules:
 </details>
 `
 
-	formatUsernames := make([]string, 0, len(r.usernames))
-	for _, u := range r.usernames {
+	formatUsernames := make([]string, 0, len(r.Winners))
+	for _, u := range r.Winners {
 		formatUsernames = append(formatUsernames, "@"+u)
 	}
 
 	unavailableMessage := ""
-	if r.unavailablePlayers > 0 {
-		players := english.Plural(r.unavailablePlayers, "player", "")
+	if r.UnavailablePlayers > 0 {
+		players := english.Plural(r.UnavailablePlayers, "player", "")
 		unavailableMessage = fmt.Sprintf(", %s - unavailable", players)
 	}
 
 	return fmt.Sprintf(
 		"🎲 **Review Roulette** — %d contributors in the pool%s\n\n 🧠 Reviewers selected: %s\n\n %s",
-		r.totalPlayers,
+		r.TotalPlayers,
 		unavailableMessage,
 		strings.Join(formatUsernames, ","),
 		rules,
 	)
 }
 
-func (r Request) spinRoulette(num int) (*rouletteResult, error) {
+func (r Request) spinRoulette(num int) (*RouletteResult, error) {
 	gamblers, err := r.provider.GetContributors(r.info.ProjectID, r.info.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	result := rouletteResult{
-		totalPlayers: len(gamblers),
+	result := RouletteResult{
+		TotalPlayers: len(gamblers),
 	}
 
 	counts, err := cache.GetCounts(r.info.ProjectID)
@@ -382,7 +383,7 @@ func (r Request) spinRoulette(num int) (*rouletteResult, error) {
 
 	for i := range gamblers {
 		if !gamblers[i].IsAvailable() {
-			result.unavailablePlayers++
+			result.UnavailablePlayers++
 		}
 	}
 
@@ -429,43 +430,36 @@ func (r Request) spinRoulette(num int) (*rouletteResult, error) {
 		}
 	}
 
-	result.usernames = usernames
+	result.Winners = usernames
 
 	return &result, nil
 }
 
-func (r Request) reviewRoulette(num int) error {
+func (r Request) reviewRoulette(num int) (*RouletteResult, error) {
 	if len(r.info.Reviewers) != 0 {
-		if err := r.provider.LeaveComment(r.info.ProjectID, r.info.ID, "🎲 Merge Request has assigned reviewers already"); err != nil {
-			return err
-		}
-		return nil
+		return nil, ReviewersAssignedError
 	}
 
 	result, err := r.spinRoulette(max(num, 1))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	logger.Debug("usernames for review", "usernames", result.usernames)
-	for _, u := range result.usernames {
+	logger.Debug("usernames for review", "usernames", result.Winners)
+	for _, u := range result.Winners {
 		if _, err := cache.IncrCount(r.info.ProjectID, u); err != nil {
 			logger.Error("can't increment count", "err", err)
 		}
 	}
 
-	if len(result.usernames) == 0 {
-		return nil
-	}
-
-	if err := r.provider.LeaveComment(r.info.ProjectID, r.info.ID, result.String()); err != nil {
-		return err
-	}
-
-	return r.provider.AssignReviewers(r.info.ProjectID, r.info.ID, result.usernames)
+	return result, nil
 }
 
-func (r Request) AssignReviewers() error {
+func (r Request) AssignReviewers(usernames []string) error {
+	return r.provider.AssignReviewers(r.info.ProjectID, r.info.ID, usernames)
+}
+
+func (r Request) AutoAssignReviewers() error {
 	if !r.config.AssignReviewers.Enabled {
 		return nil
 	}
@@ -476,13 +470,26 @@ func (r Request) AssignReviewers() error {
 	}
 
 	if ok {
-		return r.reviewRoulette(r.config.AssignReviewers.ReviewerNumber)
+		result, err := r.reviewRoulette(r.config.AssignReviewers.ReviewerNumber)
+		if err != nil {
+			if errors.Is(err, ReviewersAssignedError) {
+				return nil
+			}
+
+			return err
+		}
+
+		if len(result.Winners) == 0 {
+			return nil
+		}
+
+		return r.AssignReviewers(result.Winners)
 	} else {
 		return nil
 	}
 }
 
-func (r Request) ReviewRoulette(num int) error {
+func (r Request) ReviewRoulette(num int) (*RouletteResult, error) {
 	if num == 0 {
 		num = r.config.AssignReviewers.ReviewerNumber
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review roulette feedback is more informative: it now includes computed availability (unavailable count) and highlights the selected winners along with embedded HTML rules.
* **Bug Fixes**
  * When reviewers are already assigned, the workflow no longer fails; it leaves an informational “already assigned” message (or silently skips in the auto-assign flow).
  * If no eligible winners are found, it posts “no available players” and skips reviewer assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->